### PR TITLE
Enable binary_operator_spaces

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -25,6 +25,9 @@ class Config extends Base
 			'array_syntax' => [
 				'syntax' => 'short',
 			],
+			'binary_operator_spaces' => [
+				'default' => 'single_space',
+			],
 			'blank_line_after_namespace' => true,
 			'blank_line_after_opening_tag' => true,
 			'braces' => [


### PR DESCRIPTION
Docs at https://github.com/FriendsOfPhp/PHP-CS-Fixer.

This is also used by Symfony.

I like it because it gives consistency.

Demo: https://github.com/nextcloud/server/pull/23189