### PR TITLE
exclude buggy php-cs-fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.2|^8.0",
-        "friendsofphp/php-cs-fixer": "^2.17"
+        "friendsofphp/php-cs-fixer": "^2.17 !=2.18.4"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
All my CI Tests failed due to a bug in php-cs-fixer 2.18.4. The bug is confirmed and fixed, but the fix is not yet released since days, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5566

With this PR, the buggy version is excluded, but after released, the fixed version will be used automatically.

Please create a new patch release after merging :-)