### PR TITLE
Order imports alphabetically

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -46,6 +46,7 @@ class Config extends Base {
 			'no_trailing_whitespace' => true,
 			'no_trailing_whitespace_in_comment' => true,
 			'no_unused_imports' => true,
+			'ordered_imports' => true,
 			'single_blank_line_at_eof' => true,
 			'single_class_element_per_statement' => true,
 			'single_import_per_statement' => true,


### PR DESCRIPTION
It seems phpstorm does not sort the use statements the same way as sort, and other editors may do yet something else.
So I propose to force the order in the coding standard so that the diff make sense and we do not argue about the order.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>