### PR TITLE
fix(rules): Replace deprecated braces rules

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -23,10 +23,9 @@ class Config extends Base {
 			],
 			'blank_line_after_namespace' => true,
 			'blank_line_after_opening_tag' => true,
-			'braces' => [
-				'position_after_anonymous_constructs' => 'same',
-				'position_after_control_structures' => 'same',
-				'position_after_functions_and_oop_constructs' => 'same',
+			'curly_braces_position' => [
+				'classes_opening_brace' => 'same_line',
+				'functions_opening_brace' => 'same_line',
 			],
 			'elseif' => true,
 			'encoding' => true,


### PR DESCRIPTION
Fix #11

Still changes things in Talk, but that looks "expected" and I couldn't find a rule for that, but at least the `{` is on the same line again

```diff
   4) lib/Participant.php
      ---------- begin diff ----------
--- /home/nickv/Nextcloud/27/server/appsbabies/spreed/lib/Participant.php
+++ /home/nickv/Nextcloud/27/server/appsbabies/spreed/lib/Participant.php
@@ -60,8 +60,8 @@
 	protected ?Session $session;
 
 	public function __construct(Room $room,
-								Attendee $attendee,
-								?Session $session) {
+		Attendee $attendee,
+		?Session $session) {
 		$this->room = $room;
 		$this->attendee = $attendee;
 		$this->session = $session;

      ----------- end diff -----------

```


### Questions

- Should we keep the old rule and keep supporting 3.2?
- Or should we remove the old rule and require cs-fixer ^3.16 in composer.json?