### PR TITLE
Extend coding standard with new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.2.0 - 2024-02-01
+### Added
+- `array_syntax`: Force short syntax for array
+- `list_syntax`: Same for list
+- `fully_qualified_strict_types`: Remove namespace from classname when there is a `use` statement, and add missing backslash for global namespace
+- `no_leading_import_slash`: Remove leading slash from `use` statement
+- `nullable_type_declaration_for_default_null_value`: Add missing `?` on type declaration for parameters defaulting to `null`. This will most likely be needed to avoid warnings in PHP 8.4.
+- `yoda_style`: forbid yoda style comparision. This replaces `null === $a` by `$a === null`.
+
+## 1.1.1 - 2023-06-23
+### Changed
+* feat: use php-cs-fixer/shim by @kesselb in https://github.com/nextcloud/coding-standard/pull/13
+
+## 1.1.0 - 2023-04-13
+### Changed
+* Order imports alphabetically by @come-nc in https://github.com/nextcloud/coding-standard/pull/10
+* fix(rules): Replace deprecated braces rules by @nickvergessen in https://github.com/nextcloud/coding-standard/pull/12
+
+## 1.0.0 – 2021-11-10
+### Breaking change
+* Update php-cs-fixer to 3.x
+* See https://github.com/nextcloud/coding-standard#upgrade-from-v0x-to-v10 for instructions.
+
 ## 0.5.0 – 2021-01-11
 ### Added
 - New rule: short list syntax

--- a/src/Config.php
+++ b/src/Config.php
@@ -37,6 +37,7 @@ class Config extends Base {
 			],
 			'indentation_type' => true,
 			'line_ending' => true,
+			'list_syntax' => true,
 			'lowercase_keywords' => true,
 			'method_argument_space' => [
 				'on_multiline' => 'ignore',

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,6 +42,7 @@ class Config extends Base {
 				'on_multiline' => 'ignore',
 			],
 			'no_closing_tag' => true,
+			'no_leading_import_slash' => true,
 			'no_spaces_after_function_name' => true,
 			'no_spaces_inside_parenthesis' => true,
 			'no_trailing_whitespace' => true,

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,7 @@ class Config extends Base {
 			'visibility_required' => [
 				'elements' => ['property', 'method', 'const']
 			],
+			'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
 		];
 	}
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,6 +18,7 @@ class Config extends Base {
 			'@PSR2' => true,
 			'align_multiline_comment' => true,
 			'array_indentation' => true,
+			'array_syntax' => true,
 			'binary_operator_spaces' => [
 				'default' => 'single_space',
 			],

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,6 +31,7 @@ class Config extends Base {
 			'elseif' => true,
 			'encoding' => true,
 			'full_opening_tag' => true,
+			'fully_qualified_strict_types' => ['leading_backslash_in_global_namespace' => true],
 			'function_declaration' => [
 				'closure_function_spacing' => 'one',
 			],

--- a/src/Config.php
+++ b/src/Config.php
@@ -46,6 +46,7 @@ class Config extends Base {
 			'no_trailing_whitespace' => true,
 			'no_trailing_whitespace_in_comment' => true,
 			'no_unused_imports' => true,
+			'nullable_type_declaration_for_default_null_value' => true,
 			'ordered_imports' => [
 				'imports_order' => ['class', 'function', 'const'],
 				'sort_algorithm' => 'alpha'


### PR DESCRIPTION
Proposition to add these rules to our standard:

- `array_syntax`: Force short syntax for array
- `list_syntax`: Same for list
- `fully_qualified_strict_types`: Remove namespace from classname when there is a `use` statement, and add missing backslash for global namespace
- `no_leading_import_slash`: Remove leading slash from `use` statement
- `nullable_type_declaration_for_default_null_value`: Add missing `?` on type declaration for parameters defaulting to `null`. This will most likely be needed to avoid warnings in PHP 8.4.
- `yoda_style`: forbid yoda style comparision. This replaces `null === $a` by `$a === null`.

I undertand that adding rules will mean a huge changelog at some point, and confuse a bit git blame and backports, but I still think it is worth it.
It avoids doing such changes by hand when cleaning up old code, it avoids arguing about these things in PR review. It improves consistency across the codebase and makes it easier to read.
And for `nullable_type_declaration_for_default_null_value` it avoids future deprecation warnings (https://wiki.php.net/rfc/deprecate-implicitly-nullable-types - Not voted yet)