### PR TITLE
fix: Remove fully_qualified_strict_types again 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.2.1 - 2024-02-01
+### Fix
+* fix: Remove `fully_qualified_strict_types` again by @nickvergessen in https://github.com/nextcloud/coding-standard/pull/16
+
 ## 1.2.0 - 2024-02-01
 ### Added
 - `array_syntax`: Force short syntax for array
 - `list_syntax`: Same for list
-- `fully_qualified_strict_types`: Remove namespace from classname when there is a `use` statement, and add missing backslash for global namespace
+- ~~`fully_qualified_strict_types`: Remove namespace from classname when there is a `use` statement, and add missing backslash for global namespace~~ - Removed in 1.2.1 due to issues
 - `no_leading_import_slash`: Remove leading slash from `use` statement
 - `nullable_type_declaration_for_default_null_value`: Add missing `?` on type declaration for parameters defaulting to `null`. This will most likely be needed to avoid warnings in PHP 8.4.
 - `yoda_style`: forbid yoda style comparision. This replaces `null === $a` by `$a === null`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For convenience you may add it to the `scripts` section of your `composer.json`:
 }
 ```
 
-*Note: Don't forget to exclude .php_cs.dist in your build scripts.*
+*Note: Don't forget to exclude `.php-cs-fixer.dist.php` and `.php-cs-fixer.cache` in your build scripts.*
 
 ## Upgrade from v0.x to v1.0
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,7 +31,6 @@ class Config extends Base {
 			'elseif' => true,
 			'encoding' => true,
 			'full_opening_tag' => true,
-			'fully_qualified_strict_types' => ['leading_backslash_in_global_namespace' => true],
 			'function_declaration' => [
 				'closure_function_spacing' => 'one',
 			],


### PR DESCRIPTION
`fully_qualified_strict_types` => `leading_backslash_in_global_namespace` we want to use was only introduced with 3.46 https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/00612231e885cb52ac3f70ca6e980ce5718d07e2