### PR TITLE
style: enable types_spaces rule

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,7 @@ class Config extends Base {
 			'single_import_per_statement' => true,
 			'single_line_after_imports' => true,
 			'switch_case_space' => true,
+			'types_spaces' => ['space' => 'none', 'space_multiple_catch' => 'none'],
 			'visibility_required' => [
 				'elements' => ['property', 'method', 'const']
 			],


### PR DESCRIPTION
I would prefer a unified way for union types ;) 

Rule:

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/930dc93a1b90eb991d13e2766a340aa6922d4a2c/doc/rules/whitespace/types_spaces.rst

Examples:

`catch(A | B)` => `catch(A|B)`

`function foo(): A | B` => `function foo(): A|B`


Affected files in server:

```
   1) apps/files_versions/lib/Storage.php
   2) apps/theming/lib/Service/BackgroundService.php
   3) apps/dav/lib/BackgroundJob/OutOfOfficeEventDispatcherJob.php
   4) apps/dav/lib/BackgroundJob/UploadCleanup.php
   5) apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
   6) apps/dav/lib/CardDAV/UserAddressBooks.php
   7) apps/dav/lib/CardDAV/SystemAddressbook.php
   8) apps/settings/lib/Controller/UsersController.php
   9) apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
  10) apps/files_sharing/lib/Controller/ShareAPIController.php
  11) lib/private/Avatar/AvatarManager.php

```