### PR TITLE
style: enforce correct order vor phpdoc var annotation

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -53,6 +53,7 @@ class Config extends Base {
 				'imports_order' => ['class', 'function', 'const'],
 				'sort_algorithm' => 'alpha'
 			],
+			'phpdoc_var_annotation_correct_order' => true,
 			'single_blank_line_at_eof' => true,
 			'single_class_element_per_statement' => true,
 			'single_import_per_statement' => true,


### PR DESCRIPTION
Rule:
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/930dc93a1b90eb991d13e2766a340aa6922d4a2c/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst

Example:
`/** @var $hello string` => `/** @var string $hello`

The rule changed three files in server. 