### PR TITLE
style: ensure indentation with method chaining

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,7 @@ class Config extends Base {
 			'method_argument_space' => [
 				'on_multiline' => 'ignore',
 			],
+			'method_chaining_indentation' => true,
 			'no_closing_tag' => true,
 			'no_leading_import_slash' => true,
 			'no_spaces_after_function_name' => true,


### PR DESCRIPTION
Rule:
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/930dc93a1b90eb991d13e2766a340aa6922d4a2c/doc/rules/whitespace/method_chaining_indentation.rst

![image](https://github.com/user-attachments/assets/32a72ea8-0511-4158-ac6e-8f2961df8103)

~60 files in server, 50% in tests. 