### PR TITLE
feat: Add rule for having one promoted property per line in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.2.4 - TBA
+
+### Changed
+* `trailing_comma_in_multiline`: Add a trailing comma to multline function parameters
+* `MultilinePromotedPropertiesFixer`: Break promoted properties on multiple lines
+
 ## 1.2.3 - 2024-08-23
 ### Changed
 * `cast_spaces`: No space between cast and variable

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "require": {
         "php": "^7.3|^8.0",
-        "php-cs-fixer/shim": "^3.17"
+        "php-cs-fixer/shim": "^3.17",
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
     },
     "license": "MIT",
     "authors": [

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,7 @@ class Config extends Base {
 	public function __construct($name = 'default') {
 		parent::__construct($name);
 		$this->setIndent("\t");
+		$this->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers());
 	}
 
 	public function getRules() : array {
@@ -72,6 +73,7 @@ class Config extends Base {
 				'elements' => ['property', 'method', 'const']
 			],
 			'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+			PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer::name() => true,
 		];
 	}
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nextcloud\CodingStandard;
 
 use PhpCsFixer\Config as Base;
+use PhpCsFixerCustomFixers;
 
 class Config extends Base {
 	public function __construct($name = 'default') {
@@ -68,6 +69,7 @@ class Config extends Base {
 			'single_line_after_imports' => true,
 			'single_quote' => ['strings_containing_single_quote_chars' => false],
 			'switch_case_space' => true,
+			'trailing_comma_in_multiline' => ['elements' => ['parameters']],
 			'types_spaces' => ['space' => 'none', 'space_multiple_catch' => 'none'],
 			'visibility_required' => [
 				'elements' => ['property', 'method', 'const']


### PR DESCRIPTION
This will help especially when using rector to add promoted properties because it makes sure they are each on their own lines.

Example diff from the changes:
```diff
 
diff --git a/apps/dav/lib/CalDAV/TimezoneService.php b/apps/dav/lib/CalDAV/TimezoneService.php
index 93f19be1b55..a7709bde0f9 100644
--- a/apps/dav/lib/CalDAV/TimezoneService.php
+++ b/apps/dav/lib/CalDAV/TimezoneService.php
@@ -20,9 +20,11 @@ use function array_reduce;
 
 class TimezoneService {
 
-       public function __construct(private IConfig $config,
+       public function __construct(
+               private IConfig $config,
                private PropertyMapper $propertyMapper,
-               private IManager $calendarManager) {
+               private IManager $calendarManager,
+       ) {
        }
```