### PR TITLE
feat: Add rule for having one promoted property per line in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 1.2.4 - TBA
+## 1.3.0 - TBA
 
 ### Changed
 * `trailing_comma_in_multiline`: Add a trailing comma to multline function parameters
 * `MultilinePromotedPropertiesFixer`: Break promoted properties on multiple lines
+* `ErickSkrauch/blank_line_before_return`: Add a blank line before each return
+* `ErickSkrauch/line_break_after_statements`: Add a blank line after all control statements
 
 ## 1.2.3 - 2024-08-23
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "php-cs-fixer/shim": "^3.17",
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22",
+        "erickskrauch/php-cs-fixer-custom-fixers": "^1.3"
     },
     "license": "MIT",
     "authors": [

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,7 @@ class Config extends Base {
 		parent::__construct($name);
 		$this->setIndent("\t");
 		$this->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers());
+		$this->registerCustomFixers(new \ErickSkrauch\PhpCsFixer\Fixers());
 	}
 
 	public function getRules() : array {
@@ -76,6 +77,8 @@ class Config extends Base {
 			],
 			'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
 			PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer::name() => true,
+			'ErickSkrauch/blank_line_before_return' => true,
+			'ErickSkrauch/line_break_after_statements' => true,
 		];
 	}
 }


### PR DESCRIPTION
Based on https://github.com/nextcloud/coding-standard/pull/31 to avoid conflicts.

See
https://github.com/erickskrauch/php-cs-fixer-custom-fixers?tab=readme-ov-file#erickskrauchblank_line_before_return
and
https://github.com/erickskrauch/php-cs-fixer-custom-fixers?tab=readme-ov-file#erickskrauchline_break_after_statements.