### PR TITLE
style: add operator_linebreak

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -57,6 +57,9 @@ class Config extends Base {
 			'no_unused_imports' => true,
 			'nullable_type_declaration_for_default_null_value' => true,
 			'nullable_type_declaration' => ['syntax' => 'question_mark'],
+			'operator_linebreak' => [
+				'position' => 'beginning',
+			],
 			'ordered_imports' => [
 				'imports_order' => ['class', 'function', 'const'],
 				'sort_algorithm' => 'alpha'


### PR DESCRIPTION
Ensure that conditional statements are split into multiple lines and that the operator is placed at the beginning. This actually implements the style described in https://docs.nextcloud.com/server/latest/developer_manual/getting_started/codingguidelines.html#control-structures

```diff
...
diff --git a/apps/dav/lib/CalDAV/BirthdayService.php b/apps/dav/lib/CalDAV/BirthdayService.php
index e1e46316d74..680b228766f 100644
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -295,8 +295,8 @@ class BirthdayService {
                }
 
                return (
-                       $newCalendarData->VEVENT->DTSTART->getValue() !== $existingBirthday->VEVENT->DTSTART->getValue() ||
-                       $newCalendarData->VEVENT->SUMMARY->getValue() !== $existingBirthday->VEVENT->SUMMARY->getValue()
+                       $newCalendarData->VEVENT->DTSTART->getValue() !== $existingBirthday->VEVENT->DTSTART->getValue()
+                       || $newCalendarData->VEVENT->SUMMARY->getValue() !== $existingBirthday->VEVENT->SUMMARY->getValue()
                );
        }
 
diff --git a/apps/dav/lib/CalDAV/CalDavBackend.php b/apps/dav/lib/CalDAV/CalDavBackend.php
index c9d323d27df..b1e31733b7a 100644
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -394,8 +394,8 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
                                                // New share can not have more permissions than the old one.
                                                continue;
                                        }
-                                       if (isset($calendars[$row['id']][$readOnlyPropertyName]) &&
-                                               $calendars[$row['id']][$readOnlyPropertyName] === 0) {
+                                       if (isset($calendars[$row['id']][$readOnlyPropertyName])
+                                               && $calendars[$row['id']][$readOnlyPropertyName] === 0) {
                                                // Old share is already read-write, no more permissions can be gained
                                                continue;
                                        }
@@ -1929,8 +1929,8 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
                if ($pattern !== '') {
                        $innerQuery->andWhere($innerQuery->expr()->iLike('op.value',
-                               $outerQuery->createNamedParameter('%' .
-                                       $this->db->escapeLikeParameter($pattern) . '%')));
+                               $outerQuery->createNamedParameter('%'
+                                       . $this->db->escapeLikeParameter($pattern) . '%')));
                }
 
                $start = null;
...
```

Downside: a lot if fixes in server:

```
 223 files changed, 1864 insertions(+), 1875 deletions(-)
```