### PR TITLE
build(deps): drop PHP 7.x for incompatiblity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Nextcloud coding standards for the php cs fixer",
     "type": "library",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "php-cs-fixer/shim": "^3.17",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
     },


### PR DESCRIPTION
Some rules that we have are incompatible with PHP 7.4 and lead to failing linters. It is fair to drop support of those version imo.

Example: trailing `,` on last argument in a method's parameter list.