### PR TITLE
feat: Set precise rules for blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.5.0 — 2026-05-19
+### Added
+* `blank_lines_before_namespace`: Make sure a blank line precedes the namespace declaration
+* `no_extra_blank_lines`: Remove extra blank lines where they are not needed to improve readability
+
 ## 1.4.0 — 2025-07-19
 ### Added
 * `no_whitespace_in_blank_line`: Remove trailing whitespace at the end of blank lines

--- a/src/Config.php
+++ b/src/Config.php
@@ -26,6 +26,7 @@ class Config extends Base {
 			],
 			'blank_line_after_namespace' => true,
 			'blank_line_after_opening_tag' => true,
+			'blank_lines_before_namespace' => ['min_line_breaks' => 2, 'max_line_breaks' => 2],
 			'cast_spaces' => ['space' => 'none'],
 			'concat_space' => ['spacing' => 'one'],
 			'curly_braces_position' => [
@@ -51,6 +52,11 @@ class Config extends Base {
 				'elements' => ['property', 'method', 'const']
 			],
 			'no_closing_tag' => true,
+			'no_extra_blank_lines' => [
+				'tokens' => [
+					'attribute', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait'
+				]
+			],
 			'no_leading_import_slash' => true,
 			'no_short_bool_cast' => true,
 			'no_spaces_after_function_name' => true,


### PR DESCRIPTION
Hello,

The point of this PR is to add a rule to remove extra blank lines in PHP files (because I saw way too many of them in circles app and it hurts readability), also I take the opportunity to try to standardize files headers so that they look like this:

```php
<?php

declare(strict_types=1);

/**
 * SPDX-FileCopyrightText: <license text>
 * SPDX-License-Identifier: <license id>
 */

namespace OC\…;

use OCP\…;
use OCP\…;

class MyClass {
```

The only blank line in there that cannot be forced by coding-standard is the one between the declare and the phpdoc for license. There is no rule for that.

Tools like rector may also result in extra blank lines in some situations so it’s quite an improvement if the coding standard removes them.

I enabled most of the options from https://cs.symfony.com/doc/rules/whitespace/no_extra_blank_lines.html
I removed the ones related to case/default/break as I have no strong preference and we have both ways in our code.
I removed curly_brace_block for the same reason, some classes start with a blank line and some not, and I’m fine with that. I can add it back if suitable.
I removed commas because it’s not supported by our version of cs-fixer but we may want to upgrade the dependency.